### PR TITLE
Merging bugfix-escape-doublequotes into the main branch

### DIFF
--- a/SoundsDownloadScript.ps1
+++ b/SoundsDownloadScript.ps1
@@ -260,14 +260,11 @@ If (($Download -eq 1) -OR ($NoDL) -OR ($Force)) {
     # Load the Sounds page to grab the tag information
     $SoundsShowPage = (Invoke-WebRequest –Uri $SoundsPlayLink -Method Get -UseBasicParsing -ContentType "text/plain; charset=utf-8").Content
 
-	# Replace any fancy quotes with normal ones
-	$smartSingleQuotes = '[\u2019\u2018]'
-	$smartDoubleQuotes = '[\u201C\u201D]'
-	$SoundsShowPage = $SoundsShowPage -replace $smartSingleQuotes,"'" -replace $smartDoubleQuotes,'"'
-
 	# Parse the metadata section from the Sounds page and read it as JSON
 	$Getjson = "(?<=<script> window.__PRELOADED_STATE__ = )(.*?)(?=; </script>)"
 	$jsonResult = [regex]::match($SoundsShowPage, $Getjson)
+	 # Clean up stupid smart quotes
+	$jsonResult = "$jsonResult" -replace '[\u201C\u201D\u201E\u201F\u2033\u2036]', "$([char]92)$([char]34)" -replace "[\u2018\u2019\u201A\u201B\u2032\u2035]", "$([char]39)"
 	$jsonData = $jsonResult | ConvertFrom-Json
 
     # Put the titles into a table

--- a/SoundsDownloadScript.ps1
+++ b/SoundsDownloadScript.ps1
@@ -263,7 +263,7 @@ If (($Download -eq 1) -OR ($NoDL) -OR ($Force)) {
 	# Parse the metadata section from the Sounds page and read it as JSON
 	$Getjson = "(?<=<script> window.__PRELOADED_STATE__ = )(.*?)(?=; </script>)"
 	$jsonResult = [regex]::match($SoundsShowPage, $Getjson)
-	 # Clean up stupid smart quotes
+	# Clean up stupid smart quotes
 	$jsonResult = "$jsonResult" -replace '[\u201C\u201D\u201E\u201F\u2033\u2036]', "$([char]92)$([char]34)" -replace "[\u2018\u2019\u201A\u201B\u2032\u2035]", "$([char]39)"
 	$jsonData = $jsonResult | ConvertFrom-Json
 


### PR DESCRIPTION
Double quotes were not being escaped so the JSON parser was choking.
```
$jsonResult = "$jsonResult" -replace '[\u201C\u201D\u201E\u201F\u2033\u2036]', "$([char]92)$([char]34)" -replace "[\u2018\u2019\u201A\u201B\u2032\u2035]", "$([char]39)"
```
Added the above code to the script with escapes the double quote with a backslash. It also catches more fancy quotes than the old routine did.