### PR TITLE
Double or single quotes can now be used to define strings in genRSS.ps1 profiles

### DIFF
--- a/ProfileTemplate
+++ b/ProfileTemplate
@@ -28,7 +28,7 @@ Block=no
 
 # Episode Options
 MediaRootURL=https://yourwebsite.com/TheUnbelievableTruth/
-RerunLabel=Repeat:
+RerunLabel="Repeat: "
 RerunFiles=m000k2td,m000k7jr,m000kntz,m000kmk3,m000kw52,m000l2bn,m001mc5p
 RerunTitles=Series 24
 SkipFiles=

--- a/genRSS.ps1
+++ b/genRSS.ps1
@@ -34,9 +34,11 @@ If ($Debug) {
 
 $Recurse = $false
 
-$ScriptDir = Split-Path $script:MyInvocation.MyCommand.Path
-
 $Config = Get-Content -Raw -Path $Profile | ConvertFrom-StringData
+
+ForEach ($key in $($Config.keys)) {
+    $Config[$key] = $Config[$key] -Replace "^[`"`']" -Replace "[`"`']$"
+	}
 
 If (($Config['Debug'] -eq 'yes') -AND (!$Debug) -AND (!$TranscriptStarted)) {
 	$Debug = $true
@@ -228,7 +230,7 @@ try {$SkipTitles = $Config['SkipTitles'].Split(",")} catch {}
 		$FlaggedRerun = $false
 		ForEach ($RerunItem in $RerunFiles) {
 			If ($item -like "*$RerunItem*") {
-				$Title = "$RerunLabel $Title"
+				$Title = "$RerunLabel$Title"
 				$FlaggedRerun = $true
 				Break
 				}
@@ -237,7 +239,7 @@ try {$SkipTitles = $Config['SkipTitles'].Split(",")} catch {}
 	If (($RerunLabel) -AND ($RerunTitles) -AND (!$FlaggedRerun)) {
 		ForEach ($RerunItem in $RerunTitles) {
 			If ($Title -like "*$RerunItem*") {
-				$Title = "$RerunLabel $Title"
+				$Title = "$RerunLabel$Title"
 				Break
 				}
 			}


### PR DESCRIPTION
Double or single quotes can now be used to define strings in genRSS profiles. These are required if the value ends in a space.

```RerunLabel="Repeat: "```

NOTE: This change also brings ```$Title = "$RerunLabel$Title"``` instead of ```$Title = "$RerunLabel $Title"``` used previously. this means that you will HAVE to put in quotes if you want a space between the rerun label and the title because the script will not put it in automatically anymore.