### PR TITLE
genRSS.ps1 can now detect whether an episode is a repeat

### DIFF
--- a/ProfileTemplate
+++ b/ProfileTemplate
@@ -29,7 +29,7 @@ Block=no
 # Episode Options
 MediaRootURL=https://yourwebsite.com/TheUnbelievableTruth/
 RerunLabel="Repeat: "
-DetectReruns=yes
+AutoDetectReruns=yes
 RerunFiles=m000k2td,m000k7jr,m000kntz,m000kmk3,m000kw52,m000l2bn,m001mc5p
 RerunTitles=Series 24
 SkipFiles=

--- a/ProfileTemplate
+++ b/ProfileTemplate
@@ -29,6 +29,7 @@ Block=no
 # Episode Options
 MediaRootURL=https://yourwebsite.com/TheUnbelievableTruth/
 RerunLabel="Repeat: "
+DetectReruns=yes
 RerunFiles=m000k2td,m000k7jr,m000kntz,m000kmk3,m000kw52,m000l2bn,m001mc5p
 RerunTitles=Series 24
 SkipFiles=

--- a/README.htm
+++ b/README.htm
@@ -191,7 +191,7 @@
 				</ul>
 			<li>Copy the ProfileTemplate file to the directory that genRSS.ps1 is in.</li>
 			<li>Copy and edit the ProfileTemplate file:<br>
-				Note: Paths with a backslash (\) need to be escaped by using double (\\)
+				Note: Paths with a backslash (\) need to be escaped by using double (\\). Values may be surrounded by single or double quotes.
 				<ul>
 					<li><code>MediaDirectory</code>: The directory with your downloaded SoundsDownloadScript files to scan. <em>Directory path</em>.</li>
 					<li><code>Recursive</code>: Search subdirectories of <code>MediaDirectory</code>. <em>yes/no</em>.</li>
@@ -204,10 +204,12 @@
 					<li><code>RemotePublishDirectory</code>: This is the remote and directory that rclone should upload the RSS file to. It should be in the form of 'Remote:Directory'. Remote is the name of the appropriate config found in the config file specified in <code>-rcloneConfig</code>. For services that use the S3 API, use Remote:BucketName\Directory. <em>String</em>.</li>
 					<li><code>RemoteRSSFileName</code>: Name of the RSS file to publish remotely. <em>File name</em>.<br><br></li>
 
+					<li><code>PodcastDescription</code>: Populates the &lt;description&gt; and &lt;itunes:summary&gt; tags. Value will be marked as CDATA and can technically contain html tags, although many podcast apps will only support plain text in the description field.</li> 
 					<li><code>Block</code>: If this is set to <code>yes</code>, some podcast aggregators like Podcast Addict will not publish it in their directories, sort of like noindex. You might want to use this for testing when you first create a podcast feed. If this is absent, <code>no</code> is assumed. <em>yes/no</em>.<br><br></li>
 
 					<li><code>MediaRootURL</code>: This should be the publicly accessible URL path that podcast tools can download the episodes. <em>URL</em>.</li>
-					<li><code>RerunLabel</code>: A label to prepend to episode titles when the episode is a rerun according to the criteria in <code>RerunFiles</code> or <code>RerunTitles</code>. Include a delimiting character like a colon or dash if you'd like. A space is automatically inserted. A good default is <code>Repeat:</code> <em>String</em>.</li>
+					<li><code>RerunLabel</code>: A label to prepend to episode titles when the episode is a rerun according to the criteria in <code>RerunFiles</code> or <code>RerunTitles</code>. Include a delimiting character like a colon or dash if you'd like. A space is NOT automatically included. To include a space between the label and the title, surround the value in quotes or double quotes (<code>"Repeat: "</code>). <em>String</em>.</li>
+					<li><code>DetectReruns</code>: Try to determine whether the episode is a rerun by comparing the original date (Original Date or TDOR) to the release date (Release Date or TOAL). If it's over 60 days, the script marks it as a rerun. <em>yes/no</em>.</li>
 					<li><code>RerunFiles</code>: Searches the episode file names for this text to decide whether it's a rerun. Separate entries by a comma with no space. I recommend using the BBC program ID. <em>String</em>.</li>
 					<li><code>RerunTitles</code>: Searches the episode titles for this text to decide whether it's a rerun. Separate entries by a comma and without a space. I suggest putting the Series numbers in here (Ex: <code>Series 21,Series 22</code>). <em>String</em>.</li>
 					<li><code>SkipFiles</code>: Searches the episode file names for this text to decide whether to skip the file. Separate entries by a comma. I recommend using the BBC program ID. These episodes will not be included in the RSS. <em>String</em>.</li>

--- a/genRSS.ps1
+++ b/genRSS.ps1
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2024 endkb (https://github.com/endkb)
 # MIT License (see README.htm for details)
 

--- a/genRSS.ps1
+++ b/genRSS.ps1
@@ -225,10 +225,6 @@ try {$SkipTitles = $Config['SkipTitles'].Split(",")} catch {}
 				$Link = $($kid3json.result.taggedFile.tag2.frames | Where {$_.Name -eq 'WOAR'}).value
 				}
 			}
-	
-	Write-Host $Link
-	
-	Write-Host $kid3data
 
 	$EpisodeCode = $Link.split('/')[-1]
 	try {$SpecialTitle = $Config[$EpisodeCode]} catch {}

--- a/genRSS.ps1
+++ b/genRSS.ps1
@@ -256,6 +256,7 @@ try {$SkipTitles = $Config['SkipTitles'].Split(",")} catch {}
 		ForEach ($RerunItem in $RerunTitles) {
 			If ($Title -like "*$RerunItem*") {
 				$Title = "$RerunLabel$Title"
+    				$FlaggedRerun = $true
 				Break
 				}
 			}

--- a/genRSS.ps1
+++ b/genRSS.ps1
@@ -185,7 +185,7 @@ $itunesImage = createitunesRssElement -elementName 'itunes:image' -value '' -par
 $null = $itunesImage.SetAttribute('href', $Config['PodcastImage'])
 
 $RerunLabel = $Config['RerunLabel']
-$DetectReruns = $Config['DetectReruns']
+$AutoDetectReruns = $Config['AutoDetectReruns']
 try {$RerunFiles = $Config['RerunFiles'].Split(",")} catch {}
 try {$RerunTitles = $Config['RerunTitles'].Split(",")} catch {}
 
@@ -262,7 +262,7 @@ try {$SkipTitles = $Config['SkipTitles'].Split(",")} catch {}
 			}
 		}
 
-	If (($RerunLabel) -AND ($DetectReruns -eq "yes") -AND (!$FlaggedRerun)) {
+	If (($RerunLabel) -AND ($AutoDetectReruns -eq "yes") -AND (!$FlaggedRerun)) {
 		If ($($kid3json.result.taggedFile.tag2.frames | Where {$_.Name -eq 'Original Date'}).value) {
 		[DateTime]$OriginalDate = $($kid3json.result.taggedFile.tag2.frames | Where {$_.Name -eq 'Original Date'}).value
 		} Else {


### PR DESCRIPTION
If ```AutoDetectReruns``` is set to ```yes``` in the podcast profile file, then genRSS.ps1 will use the original release date to determine whether the episode is a rerun. If it is, it will apply the value of ```RerunLabel``` to the episode title. 