### PR TITLE
Changed the way script blocks are run.

### DIFF
--- a/README.htm
+++ b/README.htm
@@ -35,8 +35,8 @@
 	</head>
 	<body>
 		<h1>SoundsDownloadScript.ps1 + genRSS.ps1</h1>
-		<p><i>*Updated: 16-Oct-2024 23:19 GMT</i></p>
-		<p>These instructions are very crude and messy. Sorry for the windbag word vomit. I hope they help, though. If someone wants to convert this file into a markdown README.md for github, be my guest. The scripts are a little tedious to set up the first time, but once you get them working they're pretty reliable.</p>
+		<p><i>*Updated: 28-Oct-2024 22:45 GMT</i></p>
+		<p>These instructions are very crude and messy. Sorry for the windbag word vomit. I hope they help, though. If someone wants to convert this file into a markdown README.md for github, be my guest. The scripts are a little tedious to set up the first time, but once you get them working they're pretty reliable and easy to maintain.</p>
 		<p>I recommend you check the <a href="https://github.com/endkb/SoundsDownloadScript">repo on github</a> for the <a href="https://raw.githack.com/endkb/SoundsDownloadScript/main/README.htm">latest version of this README</a> before continuing.</p>
 		<p>If you find a bug in the scripts or something is incorrect or incomplete in the documentation, feel free to <a href="https://github.com/endkb/SoundsDownloadScript/issues">open an issue on github</a>.</p>
 		<h3>Table of Contents</h3>
@@ -167,9 +167,9 @@
 						This must be the command line executable, not the gui. You can comment this line out with <code>#</code> if not using a VPN.</li>
 					<li><code>$ytdlpExe</code>: [<i>File path</i>] Path or Get-ChildItem cmdlet to <code>yt-dlp.exe</code>.<br><br></li>
 
-					<li><code>$SortArticles</code>: [<i>Delimited string</i>] This isn't used much. This is a string of definite articles in various languages separated by a pipe (|). The script will strip these to fill tags specifically used for sorting. For example 'The Beatles' sort tags will become 'Beatles' and will get sorted in the Bs instead of the Ts. You can add your own for other languages, if needed. The caret (^)denotes the beginning of the string. Without it, it will also strip characters from the middle. Put a space after the definite article if it's its own word. For contractions like l', don't put a space. The defaults should be fine for most people, especially since this isn't music.<br></li>
+					<li><code>$SortArticles</code>: [<i>Delimited string</i>] This isn't used much. This is a string of definite articles in various languages separated by a pipe (|). The script will strip these to fill tags specifically used for sorting. For example 'The Beatles' sort tags will become 'Beatles' and will get sorted in the Bs instead of the Ts. You can add your own for other languages, if needed. The caret (^) denotes the beginning of the string. Without it, it will also strip characters from the middle. Put a space after the definite article if it's its own word. For contractions like l', don't put a space. The defaults should be fine for most people, especially since this isn't music.<br></li>
 				</ul>
-				<li>If using rclone, configure it by setting up remotes: <code>rclone.exe config</code><br>
+				<li>If using rclone to upload the files to a remote location, configure it by setting up remotes: <code>rclone.exe config</code><br>
 				<ul>
 					<li><a href="https://rclone.org/install/">See the rclone installation instructions here</a></li>
 					<li><a href="https://rclone.org/docs/">Detailed instructions for configuring specific remotes are here</a></li>
@@ -180,22 +180,27 @@
 				<br>
 				<code class="block">auth-user-pass "C:\\Program Files\\OpenVPN\\config\\[YourPasswordFile].txt"</code>
 				This will let OpenVPN connect without having to enter the credentials every time. Note the double back-slashes (<code>\\</code>) in the path.</li>
-			<li>If using rclone to upload the files to a remote that isn't an S3 bucket or the Internet Archive, edit SoundsDownloadScript.ps1 to configure the script blocks to configure the <code>rclone.exe</code> command line. Script blocks must start with <code>$remote_</code> in order to be run. You will need to be a little familiar with Powershell. Use an If statement to qualify the script block (otherwise it will always run). Something like:
-				<span><code class="block">$remote_test = {If ($RemoteConfig.$Remote.type -eq "internetarchive") {& $rcloneExe sync $SaveDir $rcloneSyncDir --create-empty-src-dirs --progress --config $rcloneConfig -v $rcloneLoggingArgs}}</code></span>
-				The <code>If</code> statement reads the ini file and checks that the remote matches the one specified. In this case, "internetarchive". You can have it check any of the properties in the ini file to match.	
-				<ul>
-					<li><code>$RemoteConfig</code> is the location of the rclone configuration file</li>
-					<li><code>$Remote</code> is the currently specified remote</li>
-				</ul>
-				If it matches, then it calls rclone with the parameters specified. Your rclone command should include all of the following parameters and variables:
+			<li>If using rclone, edit SoundsDownloadScript.ps1 and configure the script blocks to format the <code>rclone.exe</code> command line parameters to your needs. Script blocks must start with <code>$remote_</code> and must be named the same as the specified remote config in order to be run. For example, if you have an rclone remote called <code>poop</code>, you should have a script block named <code>$remote_poop</code>. This is how the script will know which rclone command to use. You will need to be a little familiar with Powershell. Something like:
+				<code class="block">$remote_poop = {<br>
+	& $rcloneExe sync $SaveDir $rcloneSyncDir --create-empty-src-dirs --progress --config $rcloneConfig -v $rcloneLoggingArgs<br>
+	}</code>
+				Your rclone commands should include all of the following parameters and variables:
 				<ul>
 					<li><code>$rcloneExe</code> is the path to rclone.exe</li>
-					<li><code>$SaveDir</code> is /local/path</li>
+					<li><code>$SaveDir</code> is the local directory (for syncing) or <code>$MediaFile</code> is the downloaded media file (for copying)</li>
 					<li><code>$rcloneSyncDir</code> is remote:path</li>
 					<li><code>--config $RemoteConfig</code> is the location of the rclone configuration file</li>
 					<li><code>-v $rcloneLoggingArgs</code> is the location to save the log file if enabled</li>
 				</ul>		
-				Different providers will need different rclone commands and options. Sometimes you'll need to include additional things like headers, depending on the remote. The script blocks can be tough to set up at first, but they allow for maximum flexibility. <a href="https://rclone.org/docs/">Read the rclone documentation for the remote you're using</a> and be ready to troubleshoot. The <a href="https://forum.rclone.org">rclone support forums</a> are very helpful. Note: the way the script is set up, rclone will not delete files from a remote unless the <code>sync</code> option is used. When it does its cleanup, it does not call  rclone, it just removes files locally.
+				Different providers will need different rclone commands and options. Sometimes you'll need to include additional things like headers, depending on the remote. <a href="https://rclone.org/docs/">Read the rclone documentation for the remote you're using</a> and be ready to troubleshoot. The <a href="https://forum.rclone.org">rclone support forums</a> are very helpful.
+				If you are using <code>rclone.exe copy</code> or <code>copyto</code>, then you will need to call the <code>Confirm-DownloadedMediaFile</code> function at the top of your script block like below:
+
+				<code class="block">$remote_poop2 = {<br>
+	Confirm-DownloadedMediaFile<br>
+	& $rcloneExe copyto $MediaFile $rcloneSyncDir --check-first --metadata --config $rcloneConfig --progress -v --dump headers $rcloneLoggingArgs<br>
+	}</code>
+
+				Calling <code>Confirm-DownloadedMediaFile</code> will exit the script block if there was no file downloaded. Otherwise if rclone runs and tries to copy a file that doesn't exist, it will throw a fit. It is not needed when using <code>sync</code>. Note: the way the script is set up, rclone will not delete files from a remote unless the <code>sync</code> option is used.
 		</ol>
 
 		<h3 id="Installation_2">genRSS.ps1 (if using)</h3>
@@ -232,7 +237,7 @@
 					<li><code>PodcastAuthor</code>: [<i>String</i>] It makes sense to use the name of the BBC station here.</li>
 					<li><code>OwnerName</code>: [<i>String</i>] You. I don't want my name out there, so I just put my domain here. This populates the &lt;itunes:owner&gt; element. If left empty, this will be omitted from the RSS.</li>
 					<li><code>OwnerEmail</code>: [<i>E-mail address</i>] An e-mail address. This populates the &lt;itunes:email&gt; element. If left empty, this will be omitted from the RSS.</li>
-					<li><code>PodcastURL</code>: [<i>URL</i>] Populates the &lt;link&gt; tag at the &lt;channel&gt; (podcast) level. I set this to the BBC program page of the show.</li>
+					<li><code>PodcastURL</code>: [<i>URL</i>] Populates the &lt;link&gt; tag at the &lt;channel&gt; (podcast) level. It's supposed to be website or web page associated with a podcast. I set it to the BBC program page of the show.</li>
 					<li><code>PodcastLanguage</code>: [<i>ISO 639 language code</i>] This should be a <a href="https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes">two letter code</a>, optionally with a <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">country code</a> (ex: <code>en-US</code>).</li>
 					<li><code>PodcastCopyright</code>: [<i>String</i>] I put the BBC's info here (ex: <code>(C) BBC 2024</code>) since I don't own the copyright for the media. If this is empty, the element will be omitted from the RSS.</li>
 					<li><code>Category</code>: [<i>String array</i>] Specify one or more categories to define the podcast. Categories may be separated by a comma with no space in between. Subcategories can be specified with a <code>&gt;</code> angle bracket. The first value will be the category. An unlimited number of subcategories can be specified. Take the example:
@@ -357,6 +362,10 @@
 		
 		<i>Audio file name:</i>
 		<p>The naming format for finished audio file is [ShortTitle]-[YYYYMMDD]-[Program ID]. If you decide to change that format, you could break some things unintentionally. For example, the script specifically looks for the 8-character Program ID in the file name to decide whether it's already been downloaded. genRSS.ps1 also relies on it for certain options. The script also uses a regex pattern to match files to delete if the <code>-Archive</code> parameter is set. Just be sure you update all of those things if you make changes to the file name format.</p>
+
+		<i>RCLONE script blocks:</i>
+		<p>If rclone is enabled, the script will take a hash of the <code>-SaveDir</code> and save it to a user-level environment variable with the same name as the SaveDir. This will track folder changes between instances. It will then take a hash of the SaveDir after running and compare the two hashes to decide whether to run the through the script blocks to run rclone.</p>
+		<p>You can test whether the environment variable is working properly by checking the <code>$SaveDirHashIsFromEnvVar</code> variable in the Console+Vars log. If it's <code>$true</code> then the hash was successfully pulled from the environment variable. If it's <code>$false</code>, then it couldn't find the variable and it generated the hash on the fly.</p>
 
 		<i>Tags with special characters:</i>
 		<p>Certain special characters have to be escaped with a backslash (<code>\</code>) in kid3 or kid3 will choke. I don't think a complete list exists. SoundsDownloadService escapes single quotes, double quotes, and pipes in a function called Format-kid3CommandString. If you find another character that needs to be escaped, you can add it to the <code>Return</code> line using the <code>replace</code> method.

--- a/SoundsDownloadScript.ps1
+++ b/SoundsDownloadScript.ps1
@@ -67,9 +67,10 @@ $SortArticles =                             # String of definite articles to tri
 "^a |^an |^el |^l'|^la |^las |^le |^les |^lo |^los |^the |^un |^una |^une "
 
 <#	SCRIPT BLOCKS: Configure script blocks below to run rclone commands depending on the remote backend. New ones can be included. Script blocks must be
-	stored in vars that start with 'remote_'. Use the 'If' statement to match the remote type found in the rclone config file. See https://rclone.org/docs/	#>
+	stored in vars that start with 'remote_'. The other half of the var name should match the remote name in the rclone config file. See https://rclone.org/docs/	#>
 # Internet Archive
-$remote_ia = {If ($RemoteConfig.$Remote.type -eq "internetarchive") {
+$remote_internetarchive_config = {
+	Confirm-DownloadedMediaFile
 	# Build the headers to set the metadata - See https://archive.org/developers/metadata-schema/index.html and https://github.com/vmbrasseur/IAS3API/blob/master/metadata.md#setting-metadata-values-via-headers
 	$iaHeaders = @( )
 	$iaHeaders += "--header", "X-Archive-Meta-Collection: opensource_audio"
@@ -90,18 +91,27 @@ $remote_ia = {If ($RemoteConfig.$Remote.type -eq "internetarchive") {
 	# Create a page with the metadata and upload the cover art
 	& $rcloneExe copyto "$DumpDirectory\$ImageName" "$rcloneSyncDir\$(([system.io.fileinfo]$MoveLoc).BaseName)\$(([system.io.fileinfo]$MoveLoc).BaseName)_itemimage.jpg" $iaHeaders --metadata --config $rcloneConfig --progress -v --dump headers $rcloneLoggingArgs
 	# Upload the audio file to the page
-	& $rcloneExe copyto $MoveLoc "$rcloneSyncDir$(([system.io.fileinfo]$MoveLoc).BaseName)\$(Split-Path $MoveLoc -leaf)" --metadata --config $rcloneConfig --progress -v --dump headers $rcloneLoggingArgs
-	}}
+	& $rcloneExe copyto $MoveLoc "$rcloneSyncDir$(([system.io.fileinfo]$MoveLoc).BaseName)\$(Split-Path $MoveLoc -leaf)" --check-first --metadata --config $rcloneConfig --progress -v --dump headers $rcloneLoggingArgs
+	}
 
 # Cloudflare Storage
-$remote_r2 = {If ($RemoteConfig.$Remote.provider -eq "Cloudflare") {
+$remote_bbcsoundsrss_r2 = {
 	# Sync the SaveDir with the remote dir
-	& $rcloneExe sync $SaveDir $rcloneSyncDir --create-empty-src-dirs --progress --config $rcloneConfig -v $rcloneLoggingArgs
-	}}
+	& $rcloneExe sync $SaveDir $rcloneSyncDir --check-first --create-empty-src-dirs --progress --config $rcloneConfig -v $rcloneLoggingArgs
+	}
 
 <#      ┌────────────────────────────────────────────────────────────────────────────────┐
         │                   ▲    End script configuration options    ▲                   │
         └────────────────────────────────────────────────────────────────────────────────┘      #>
+
+# Checks if a media file was downloaded - if not it exits the script block
+# Call this function at the top of script blocks that copy the media file instead of syncing a directory
+Function Confirm-DownloadedMediaFile {
+	If (-not [System.IO.File]::Exists($MoveLoc)) {
+		Write-Output "**Exiting script block: No media file to transfer"
+		Break
+		}
+	}
 
 Function Exit-Script {
 	# Clean up the cover art from the DumpDirectory
@@ -169,7 +179,7 @@ Function Invoke-LoggingRoutine {
 	# Create the directory to save/move logs to
 	New-Item -ItemType Directory -Force -Path "$LogDirectory" > $null
 	$Script:LogFileDate = Get-Date
-	
+
 	# Build a command line arguments for openvpn and rclone to output logs
 	$Script:vpnLoggingArgs = "--log-append `"$LogDirectory\$(Set-LogFileName -LogType 'vpn')`""
 	$Script:rcloneLoggingArgs = "--log-file", "$LogDirectory\$(Set-LogFileName -LogType 'rclone')"
@@ -177,7 +187,7 @@ Function Invoke-LoggingRoutine {
 	# Start recording the console
 	Start-Transcript -Path "$LogDirectory\$(Set-LogFileName -LogType 'Console+Vars')" -Append -IncludeInvocationHeader -Verbose
 	$Script:TranscriptStarted = $true
-	Write-Output "**Logging: Saving log files to $LogDirectory\$(Set-LogFileName -LogType '*')"	
+	Write-Output "**Logging: Saving log files to $LogDirectory\$(Set-LogFileName -LogType '*')"
 	}
 
 Function Set-LogFileName {
@@ -246,6 +256,22 @@ If (($Logging) -AND ($TranscriptStarted -ne $true)) {
 	Invoke-LoggingRoutine
 	}
 
+If (($rcloneConfig) -AND ($rcloneSyncDir)) {
+	# Grab the saved hash from the last time the script ran to compare changes later
+	If ([System.Environment]::GetEnvironmentVariable($SaveDir)) {
+		$SaveDirHashBefore = [System.Environment]::GetEnvironmentVariable($SaveDir)
+		# For troubleshooting only
+		$SaveDirHashIsFromEnvVar = $true
+		} Else {
+			# If the hash isn't already saved get it now
+			$MediaFileListBefore = Get-ChildItem -Path $SaveDir -Recurse | Sort-Object Name | Select -Expand FullName
+			$md5hash = New-Object -TypeName System.Security.Cryptography.MD5CryptoServiceProvider
+			$utf = New-Object -TypeName System.Text.UTF8Encoding
+			$SaveDirHashBefore = [System.BitConverter]::ToString($md5hash.ComputeHash($utf.GetBytes($MediaFileListBefore))).Replace("-", "")
+			# For troubleshooting only
+			$SaveDirHashIsFromEnvVar = $false
+			}
+	}
 # Don't bother searching the page if ProgramURL is already a Sounds link
 If ($ProgramURL -like "https://www.bbc.co.uk/sounds/play/*") {
 	$SoundsPlayLink = $ProgramURL
@@ -418,7 +444,7 @@ If (($Download -eq 1) -OR ($NoDL) -OR ($Force)) {
 	Write-Output "**Station: $Station"
 	Write-Output "**Released On: $ReleaseDate"
 	Write-Output "**Released On: $($ReleaseDate.ToUniversalTime())"
-	
+
 	If ($Printjson) {
 		Write-Output "**Beginning of json output (line below):"
 		Write-Output $jsonResult
@@ -673,34 +699,44 @@ If (($Download -eq 1) -OR ($NoDL) -OR ($Force)) {
 			Exit-Script
 			}
 
-	# Don't clean up unless the file was sucessfully moved (for troubleshooting purposes)
-	If ([System.IO.File]::Exists($MoveLoc)) {
-		# Check if $Archive value is set
-		If ($Archive -ge 1) {
-			# RegEx pattern looks for the number pattern after the dash to account for dashes in the $ShortTitle
-			$TitleMatchPattern = "$ShortTitle-([0-9]*)-([A-Za-z0-9]*|[A-Za-z0-9]*_[0-9]*)\."
-			If (!$Days) {
-				# Remove all audio files except the most recent ones
-				Get-ChildItem $SaveDir -Recurse -Force | Where-Object { $_.Name -match $($TitleMatchPattern) } | Sort-Object LastWriteTime -Descending | Select-Object -Skip $Archive | Remove-Item -Force -Verbose
-				}
-			If ($Days) {
-				# Run through all items in the SaveDir
-				Get-ChildItem $SaveDir -Recurse -Force | Where-Object {$_.Name -match $($TitleMatchPattern)} | ForEach {
-					# Parse the release date from the title of each episode
-					$ParseReleaseDate = [regex]::match($_.Name, "(\d\d\d\d\d\d\d\d+)")
-					# Convert the release date to a DateTime object
-					$TitleReleaseDate = [Datetime]::ParseExact($ParseReleaseDate, 'yyyyMMdd', (New-Object System.Globalization.CultureInfo "en-US"))
-					# Check if the release date of the ep is older than the specified archive date
-					If ($TitleReleaseDate -lt (Get-Date).Date.AddDays(-$Archive)) {
-						# Remove it if it is
-						Remove-Item $_.FullName -Force -Verbose
-						}
-					}
+	} Else {
+		Write-Output "**Program ID $ProgramID already downloaded $($File.CreationTime)"
+		If ($ScriptInstanceControl) {Unlock-Control}
+		}
+
+If ($Archive -ge 1) {
+	# RegEx pattern looks for the number pattern after the dash to account for dashes in the $ShortTitle
+	$TitleMatchPattern = "$ShortTitle-([0-9]*)-([A-Za-z0-9]*|[A-Za-z0-9]*_[0-9]*)\."
+	If (!$Days) {
+		# Remove all audio files except the most recent ones
+		Get-ChildItem $SaveDir -Recurse -Force | Where-Object { $_.Name -match $($TitleMatchPattern) } | Sort-Object LastWriteTime -Descending | Select-Object -Skip $Archive | Remove-Item -Force -Verbose
+		}
+	If ($Days) {
+		# Run through all items in the SaveDir
+		Get-ChildItem $SaveDir -Recurse -Force | Where-Object {$_.Name -match $($TitleMatchPattern)} | ForEach {
+			# Parse the release date from the title of each episode
+			$ParseReleaseDate = [regex]::match($_.Name, "(\d\d\d\d\d\d\d\d+)")
+			# Convert the release date to a DateTime object
+			$TitleReleaseDate = [Datetime]::ParseExact($ParseReleaseDate, 'yyyyMMdd', (New-Object System.Globalization.CultureInfo "en-US"))
+			# Check if the release date of the ep is older than the specified archive date
+			If ($TitleReleaseDate -lt (Get-Date).Date.AddDays(-$Archive)) {
+				# Remove it if it is
+				Remove-Item $_.FullName -Force -Verbose
 				}
 			}
 		}
+	}
 
 	If (($rcloneConfig) -AND ($rcloneSyncDir)) {
+	# Calculate the hash again to see if changes were made
+	$MediaFileListAfter = Get-ChildItem -Path $SaveDir -Recurse | Sort-Object Name | Select -Expand FullName
+	$md5hash = New-Object -TypeName System.Security.Cryptography.MD5CryptoServiceProvider
+	$utf = New-Object -TypeName System.Text.UTF8Encoding
+	$SaveDirHashAfter = [System.BitConverter]::ToString($md5hash.ComputeHash($utf.GetBytes($MediaFileListAfter))).Replace("-", "")
+	# Save the new hash back to an environment variable
+	[System.Environment]::SetEnvironmentVariable($SaveDir, $SaveDirHashAfter)
+
+	If ($SaveDirHashAfter -ne $SaveDirHashBefore) {
 		# Function to escape double quotes in parameters before passing them to rclone
 		Function Format-rcloneCommandString ($StringToFormat) {
 			Return $StringToFormat.replace("`"","\`"")
@@ -721,15 +757,15 @@ If (($Download -eq 1) -OR ($NoDL) -OR ($Force)) {
 			$Remote = $rcloneSyncDir.Substring(0, $rcloneSyncDir.IndexOf(":"))
 			# Run through all script blocks that start with 'remote_'
 			ForEach ($RemoteItem in $(Get-Variable remote_*)) {
-				# Execute each script block (each script block determines whether it matches the remote type to run rclone)
-				& (Get-Variable -Name $RemoteItem.Name).Value
+				# Looks for a script block with a similar name to the remote config to run
+				If ($RemoteItem.Name -replace 'remote_*' -eq $Remote) {
+					Write-Output "**Running script block: $($RemoteItem.Name)"
+					# Execute the script block
+					& (Get-Variable -Name $RemoteItem.Name).Value
+					}
 				}
 			}
 		}
-
-	} Else {
-		Write-Output "**Program ID $ProgramID already downloaded $($File.CreationTime)"
-		If ($ScriptInstanceControl) {Unlock-Control}
-		}
+	}
 
 Exit-Script


### PR DESCRIPTION
Made significant changes to the way script blocks are handled. They don't use `If` statements anymore.

Script blocks must start with `$remote_` and must be named the same as the specified remote config in order to be run. For example, if you have an rclone remote called poop, you should have a script block named `$remote_poop`. This is how the script will know which rclone command to use.